### PR TITLE
Do not expose as a component to the component installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,9 +49,6 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
-        },
-        "zf": {
-            "config-provider": "Zend\\HttpHandlerRunner\\ConfigProvider"
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0ed5679bc78e39a43ee168748d1ba2f",
+    "content-hash": "d3269859a60e5674c47b47f6eeaf6dd3",
     "packages": [
         {
             "name": "psr/http-message",


### PR DESCRIPTION
We currently do not expose any services, so there's no reason to expose the component as a config provider.