### PR TITLE
Test improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
             "ZendTest\\HttpHandlerRunner\\": "test/"
         },
         "files": [
-            "test/TestAsset/Functions.php",
             "test/TestAsset/SapiResponse.php"
         ]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0ed5679bc78e39a43ee168748d1ba2f",
+    "content-hash": "8a5752a9b1c4cea64404092656944212",
     "packages": [
         {
             "name": "psr/http-message",

--- a/test/TestAsset/HeaderStack.php
+++ b/test/TestAsset/HeaderStack.php
@@ -1,19 +1,5 @@
 <?php
 /**
- * Zend Framework (https://framework.zend.com/)
- *
- * This file exists to allow overriding the various output-related functions
- * in order to test what happens during the `Server::listen()` cycle.
- *
- * These functions include:
- *
- * - headers_sent(): we want to always return false so that headers will be
- *   emitted, and we can test to see their values.
- * - header(): we want to aggregate calls to this function.
- *
- * The HeaderStack class then aggregates that information for us, and the test
- * harness resets the values pre and post test.
- *
  * @see       https://github.com/zendframework/zend-serverhandler-runnder for the canonical source repository
  * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-serverhandler-runnder/blob/master/LICENSE.md New BSD License
@@ -76,32 +62,4 @@ class HeaderStack
 
         return false;
     }
-}
-
-/**
- * Have headers been sent?
- *
- * @return false
- */
-function headers_sent()
-{
-    return false;
-}
-
-/**
- * Emit a header, without creating actual output artifacts
- *
- * @param string   $string
- * @param bool     $replace
- * @param int|null $statusCode
- */
-function header($string, $replace = true, $statusCode = null)
-{
-    HeaderStack::push(
-        [
-            'header'      => $string,
-            'replace'     => $replace,
-            'status_code' => $statusCode,
-        ]
-    );
 }

--- a/test/TestAsset/SapiResponse.php
+++ b/test/TestAsset/SapiResponse.php
@@ -11,7 +11,7 @@
  *   emitted, and we can test to see their values.
  * - header(): we want to aggregate calls to this function.
  *
- * It pushes headers into the HeaderStack class defined in Functions.php.
+ * It pushes headers into the HeaderStack class defined in HeaderStack.php.
  *
  * @see       https://github.com/zendframework/zend-serverhandler-runnder for the canonical source repository
  * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)


### PR DESCRIPTION
Removed mocking internal PHP functions in TestAsset.
These mocking has no any affect as it was in TestAsset namespace.
Renamed file to be autoloaded via composer.
Mocked function are only in SapiResponse TestAsset.
