### PR TITLE
Extract extra info from headers_sent

### DIFF
--- a/src/Emitter/SapiEmitterTrait.php
+++ b/src/Emitter/SapiEmitterTrait.php
@@ -31,8 +31,9 @@ trait SapiEmitterTrait
      */
     private function assertNoPreviousOutput()
     {
-        if (headers_sent()) {
-            throw EmitterException::forHeadersSent();
+        $file = $line = null;
+        if (headers_sent($file, $line)) {
+            throw EmitterException::forHeadersSent($file, $line);
         }
 
         if (ob_get_level() > 0 && ob_get_length() > 0) {

--- a/src/Emitter/SapiEmitterTrait.php
+++ b/src/Emitter/SapiEmitterTrait.php
@@ -31,7 +31,8 @@ trait SapiEmitterTrait
      */
     private function assertNoPreviousOutput()
     {
-        $file = $line = null;
+        $file = null;
+        $line = null;
         if (headers_sent($file, $line)) {
             throw EmitterException::forHeadersSent($file, $line);
         }

--- a/src/Exception/EmitterException.php
+++ b/src/Exception/EmitterException.php
@@ -13,9 +13,15 @@ use RuntimeException;
 
 class EmitterException extends RuntimeException implements ExceptionInterface
 {
-    public static function forHeadersSent() : self
+    public static function forHeadersSent(string $file, int $line) : self
     {
-        return new self('Unable to emit response; headers already sent');
+        return new self(
+            sprintf(
+                'Unable to emit response; headers already sent, output started at %s:%d',
+                $file,
+                $line
+            )
+        );
     }
 
     public static function forOutputSent() : self

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -67,11 +67,11 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withStatus(200)
             ->withBody($stream);
         ob_start();
-        echo 'Unexpected Output';
+        echo 'Unexpected Output'; 
         try {
             $this->emitter->emit($response);
-        } catch (Exception $e) {
-            $this->assertTrue($e instanceof EmitterException);
+        } catch (\Throwable $e) {
+            $this->assertTrue($e instanceof \EmitterException);
             $this->assertEquals('',$e->getMessage());
         } finally {
             ob_get_clean();

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -71,6 +71,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
+            var_dump($e,$e->getMessage());
             $this->assertTrue($e instanceof EmitterException);
             $this->assertEquals($e->getMessage(), sprintf(
                 'Unable to emit response; headers already sent, output started at %s:%d',

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -66,7 +66,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         $response = (new Response())
             ->withStatus(200)
             ->withBody($stream);
-        $this->expectException(EmitterException::class);
+        $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
         $this->expectExceptionMessage('Unable to emit response; headers already sent');
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -72,11 +72,17 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
             //$this->assertTrue($e instanceof Zend\HttpHandlerRunner\Exception\EmitterException);
+            $this->assertEquals(
+                'Output has been emitted previously; cannot emit response',
+                $e->getMessage()
+            );
+            /*
             $this->assertEquals($e->getMessage(),sprintf(
                 'Unable to emit response; headers already sent, output started at %s:%d',
                  __FILE__,
                  __LINE__ - 5
             ));
+            */
         } finally {
             ob_end_clean();
         }

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -71,7 +71,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
-            $this->assertTrue($e instanceof Zend\HttpHandlerRunner\Exception\EmitterException);
+            //$this->assertTrue($e instanceof Zend\HttpHandlerRunner\Exception\EmitterException);
             $this->assertEquals($e->getMessage(),sprintf(
                 'Unable to emit response; headers already sent, output started at %s:%d',
                  __FILE__,

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -67,7 +67,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withStatus(200)
             ->withBody($stream);
         $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
-        $this->expectExceptionMessage('Unable to emit response; headers already sent');
+        //$this->expectExceptionMessage('Unable to emit response; headers already sent');
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',
              __FILE__,

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -68,24 +68,24 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withBody($stream);
         $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
         //$this->expectExceptionMessage('Unable to emit response; headers already sent');
-        /*
+        
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',
              __FILE__,
              __LINE__ + 3
         ));
-        */
-        ob_start();
+        
+        //ob_start();
         echo 'Unexpected Output';
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
             throw $e;
         } finally {
-            ob_end_clean();
+            //ob_end_clean();
         }
     }
-    
+
     public function testDoesNotInjectContentLengthHeaderIfStreamSizeIsUnknown()
     {
         $stream = $this->prophesize(StreamInterface::class);

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -71,20 +71,32 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
-            //$this->assertTrue($e instanceof Zend\HttpHandlerRunner\Exception\EmitterException);
             $this->assertEquals(
                 'Output has been emitted previously; cannot emit response',
                 $e->getMessage()
             );
-            /*
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    public function testAssertNoPreviousOutputNoBuffer()
+    {
+        $stream = new CallbackStream(function () {
+            return 'it works';
+        });
+        $response = (new Response())
+            ->withStatus(200)
+            ->withBody($stream);
+        echo 'Unexpected Output';
+        try {
+            $this->emitter->emit($response);
+        } catch (\Throwable $e) {
             $this->assertEquals($e->getMessage(),sprintf(
                 'Unable to emit response; headers already sent, output started at %s:%d',
                  __FILE__,
                  __LINE__ - 5
             ));
-            */
-        } finally {
-            ob_end_clean();
         }
     }
 

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -71,8 +71,12 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
-            $this->assertTrue($e instanceof \EmitterException);
-            $this->assertEquals('',$e->getMessage());
+            $this->assertTrue($e instanceof EmitterException);
+            $this->assertEquals($e->getMessage(), sprintf(
+                'Unable to emit response; headers already sent, output started at %s:%d',
+                __FILE__,
+                __LINE__ - 5
+            ));
         } finally {
             ob_get_clean();
         }

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -67,7 +67,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withStatus(200)
             ->withBody($stream);
         $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
-        $this->expectExceptionMessage('Unable to emit response; headers already sent');
+        //$this->expectExceptionMessage('Unable to emit response; headers already sent');
         /*
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -66,20 +66,21 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         $response = (new Response())
             ->withStatus(200)
             ->withBody($stream);
+        $this->expectException(EmitterException::class);
+        $this->expectExceptionMessage('Unable to emit response; headers already sent');
+        $this->expectExceptionMessage(sprintf(
+            'output started at %s:%d',
+             __FILE__,
+             __LINE__ + 3
+        ));
         ob_start();
-        echo 'Unexpected Output'; 
+        echo 'Unexpected Output';
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
-            var_dump($e,$e->getMessage());
-            $this->assertTrue($e instanceof EmitterException);
-            $this->assertEquals($e->getMessage(), sprintf(
-                'Unable to emit response; headers already sent, output started at %s:%d',
-                __FILE__,
-                __LINE__ - 5
-            ));
+            throw $e;
         } finally {
-            ob_get_clean();
+            ob_end_clean();
         }
     }
     

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -58,6 +58,24 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         $this->assertSame('it works', ob_get_clean());
     }
 
+    public function testAssertNoPreviousOutput()
+    {
+        $stream = new CallbackStream(function () {
+            return 'it works';
+        });
+        $response = (new Response())
+            ->withStatus(200)
+            ->withBody($stream);
+        ob_start();
+        echo 'Unexpected Output';
+        try {
+            $this->emitter->emit($response);
+        } catch (Exception $e) {
+            $this->assertTrue($e instanceof EmitterException);
+            $this->assertEquals('',$e->getMessage());
+        }
+    }
+    
     public function testDoesNotInjectContentLengthHeaderIfStreamSizeIsUnknown()
     {
         $stream = $this->prophesize(StreamInterface::class);

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -66,23 +66,19 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         $response = (new Response())
             ->withStatus(200)
             ->withBody($stream);
-        $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
-        $this->expectExceptionMessage('Unable to emit response; headers already sent');
-        /*
-        $this->expectExceptionMessage(sprintf(
-            'output started at %s:%d',
-             __FILE__,
-             __LINE__ + 3
-        ));
-        */
-        //ob_start();
+        ob_start();
         echo 'Unexpected Output';
         try {
             $this->emitter->emit($response);
         } catch (\Throwable $e) {
-            throw $e;
+            $this->assertTrue($e instanceof Zend\HttpHandlerRunner\Exception\EmitterException);
+            $this->assertEquals($e->getMessage(),sprintf(
+                'Unable to emit response; headers already sent, output started at %s:%d',
+                 __FILE__,
+                 __LINE__ - 5
+            ));
         } finally {
-            //ob_end_clean();
+            ob_end_clean();
         }
     }
 

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -67,12 +67,14 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withStatus(200)
             ->withBody($stream);
         $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
-        //$this->expectExceptionMessage('Unable to emit response; headers already sent');
+        $this->expectExceptionMessage('Unable to emit response; headers already sent');
+        /*
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',
              __FILE__,
              __LINE__ + 3
         ));
+        */
         ob_start();
         echo 'Unexpected Output';
         try {

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -73,6 +73,8 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         } catch (Exception $e) {
             $this->assertTrue($e instanceof EmitterException);
             $this->assertEquals('',$e->getMessage());
+        } finally {
+            ob_get_clean();
         }
     }
     

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -67,14 +67,14 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
             ->withStatus(200)
             ->withBody($stream);
         $this->expectException('Zend\HttpHandlerRunner\Exception\EmitterException');
-        //$this->expectExceptionMessage('Unable to emit response; headers already sent');
-        
+        $this->expectExceptionMessage('Unable to emit response; headers already sent');
+        /*
         $this->expectExceptionMessage(sprintf(
             'output started at %s:%d',
              __FILE__,
              __LINE__ + 3
         ));
-        
+        */
         //ob_start();
         echo 'Unexpected Output';
         try {


### PR DESCRIPTION

**headers_sent** allows you to define a file and a line that has undesirable output, otherwise it is impossible to identify and correct the error, there is not enough of this and it is difficult to debug, but the edit is very small, but gives many possibilities, I hope this edit will fall into the main branch, thanks!

https://www.php.net/manual/en/function.headers-sent.php