### PR TITLE
Detect headers from globals, extra header from not response object

### DIFF
--- a/src/Emitter/SapiEmitterTrait.php
+++ b/src/Emitter/SapiEmitterTrait.php
@@ -38,6 +38,10 @@ trait SapiEmitterTrait
         if (ob_get_level() > 0 && ob_get_length() > 0) {
             throw EmitterException::forOutputSent();
         }
+
+        if (count(headers_list()) > 0) {
+            throw EmitterException::forHeadersFromGlobal();
+        }
     }
 
     /**

--- a/src/Exception/EmitterException.php
+++ b/src/Exception/EmitterException.php
@@ -18,6 +18,11 @@ class EmitterException extends RuntimeException implements ExceptionInterface
         return new self('Unable to emit response; headers already sent');
     }
 
+    public static function forHeadersFromGlobal() : self
+    {
+        return new self('Some headers has been emitted previously; cannot emit response');
+    }
+
     public static function forOutputSent() : self
     {
         return new self('Output has been emitted previously; cannot emit response');


### PR DESCRIPTION
Detect headers from globals, extra header from not response object

- [? ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
1. ob_get_level();
2. header('some-header: from global, not api response object');
3. ob_get_clean();
All headers from global will be send to client without response object.

  - [ ] Detail the new, expected behavior.
If some headers sent without response object emitter throw exception.

Need extra test for it. Phpunit already sent headers.